### PR TITLE
Add QC acknowledgement so accuracy alerts only report new issues

### DIFF
--- a/.github/workflows/acknowledge-qc.yml
+++ b/.github/workflows/acknowledge-qc.yml
@@ -1,0 +1,48 @@
+name: acknowledge-qc
+
+# Manually mark QC issues as reviewed & accepted so they stop triggering the
+# database-accuracy email. Run this AFTER a human has reviewed the issues and
+# decided they are acceptable. It records the current issues in
+# DataCuration/outputs/qc_acknowledged.csv and commits it. Nothing is ever
+# acknowledged automatically.
+on:
+  workflow_dispatch:
+    inputs:
+      categories:
+        description: "QC categories to accept, comma-separated (e.g. missing_OS,missing_DOI). Leave BLANK to accept ALL currently-flagged issues -- use with care."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  acknowledge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Acknowledge current QC issues
+        run: |
+          n=$(python -m DataCuration.qc_email --acknowledge \
+                --categories "${{ github.event.inputs.categories }}" \
+                --by "acknowledged via Actions by ${{ github.actor }}")
+          echo "Newly acknowledged: ${n} issue(s)."
+
+      - name: Commit the acknowledged list
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add DataCuration/outputs/qc_acknowledged.csv
+          if git diff --cached --quiet; then
+            echo "Nothing new to acknowledge."
+          else
+            git commit -m "qc: acknowledge reviewed issues (${{ github.event.inputs.categories || 'all currently flagged' }})"
+            git push
+          fi

--- a/.github/workflows/db-accuracy.yml
+++ b/.github/workflows/db-accuracy.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ steps.qc.outputs.issues != '0' }}
         uses: ./.github/actions/notify-email
         with:
-          subject: "cNPDB: database updated - QC found issues to check"
+          subject: "cNPDB: database updated - QC found new issues to check"
           body: ${{ steps.qc.outputs.body }}
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}

--- a/DataCuration/outputs/qc_acknowledged.csv
+++ b/DataCuration/outputs/qc_acknowledged.csv
@@ -1,0 +1,3 @@
+cNPDB ID,category,acknowledged_by,date,reason
+9001,missing_DOI,placeholder,2026-07-15,"EXAMPLE ROW - shows the format; ID 9001 does not exist, so this clears nothing"
+9002,missing_OS,placeholder,2026-07-15,"EXAMPLE ROW - illustrative only; delete when you record real acknowledgements"

--- a/DataCuration/qc_email.py
+++ b/DataCuration/qc_email.py
@@ -1,10 +1,20 @@
 # -*- coding: utf-8 -*-
-"""Run QC on the database and produce an email body for the accuracy alert.
+"""QC the database, alert on NEW issues, and support acknowledging reviewed ones.
 
-Used by the ``db-accuracy`` workflow after Jacey pushes an updated database.
-Writes the flagged-issues CSV, writes a plain-text email body to ``--body-out``,
-and prints the number of issues to stdout (so the workflow can decide whether to
-send). Finding issues never blocks the database update -- it only notifies.
+Used by the ``db-accuracy`` workflow. It runs QC, compares the flagged issues
+against an "acknowledged" baseline -- issues a human has reviewed and accepted --
+and emails only the issues that are **new / not yet reviewed**. Finding issues
+never blocks the database update; it only notifies.
+
+Acknowledging ("clearing") issues so they stop alerting is done through the
+``acknowledge-qc`` workflow, which calls this module with ``--acknowledge``.
+Nothing is cleared automatically -- a human decides.
+
+CLI::
+
+    python -m DataCuration.qc_email --body-out email_body.txt      # report NEW issues
+    python -m DataCuration.qc_email --acknowledge                  # accept ALL current issues
+    python -m DataCuration.qc_email --acknowledge --categories missing_OS,missing_DOI
 """
 from __future__ import annotations
 
@@ -17,44 +27,133 @@ import pandas as pd
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from DataCuration import cnpdb_qc as qc  # noqa: E402
 
+DEFAULT_OUT = os.path.join(qc.OUTPUTS_DIR, "qc_flagged_issues.csv")
+DEFAULT_ACK = os.path.join(qc.OUTPUTS_DIR, "qc_acknowledged.csv")
+ACK_COLUMNS = ["cNPDB ID", "category", "acknowledged_by", "date", "reason"]
 
-def build_body(issues: pd.DataFrame, db_len: int) -> str:
-    n = len(issues)
+
+def _key(cid, category) -> tuple[str, str]:
+    return (str(cid).strip(), str(category).strip())
+
+
+def load_acknowledged(path: str = DEFAULT_ACK) -> set[tuple[str, str]]:
+    """Set of (cNPDB ID, category) keys that have been reviewed and accepted."""
+    if path and os.path.exists(path):
+        df = pd.read_csv(path, dtype=str).fillna("")
+        return {_key(r["cNPDB ID"], r["category"]) for _, r in df.iterrows()
+                if str(r.get("category", "")).strip()}
+    return set()
+
+
+def new_issues(issues: pd.DataFrame, acknowledged: set) -> pd.DataFrame:
+    """Issues whose (cNPDB ID, category) is not in the acknowledged set."""
+    if issues.empty:
+        return issues
+    keep = issues.apply(lambda r: _key(r["cNPDB ID"], r["category"]) not in acknowledged,
+                        axis=1)
+    return issues[keep]
+
+
+def build_body(new: pd.DataFrame, db_len: int, n_suppressed: int = 0) -> str:
+    """Email body for the NEW issues. Empty string when there is nothing new."""
+    n = len(new)
     if n == 0:
-        return "The updated cNPDB database passed QC with no flagged issues."
+        return ""
     lines = [
-        f"The updated cNPDB database has {n} flagged QC issue(s) across "
-        f"{db_len} entries.",
+        f"The cNPDB database has {n} QC issue(s) that are new or not yet reviewed, "
+        f"across {db_len} entries.",
         "These do NOT block the database update, but should be checked.",
         "",
         "By severity:",
     ]
-    lines += [f"  {sev}: {c}" for sev, c in issues["severity"].value_counts().items()]
+    lines += [f"  {s}: {c}" for s, c in new["severity"].value_counts().items()]
     lines += ["", "By category:"]
-    lines += [f"  {cat}: {c}" for cat, c in issues["category"].value_counts().items()]
-    lines += ["", "The full itemized list is committed to "
-              "DataCuration/outputs/qc_flagged_issues.csv"]
+    lines += [f"  {cat}: {c}" for cat, c in new["category"].value_counts().items()]
+    if n_suppressed:
+        lines += ["", f"({n_suppressed} previously-acknowledged issue(s) are not shown.)"]
+    lines += [
+        "",
+        "Full list (all issues):  DataCuration/outputs/qc_flagged_issues.csv",
+        "Acknowledged list:       DataCuration/outputs/qc_acknowledged.csv",
+        "",
+        "To stop being alerted about issues you have reviewed and accepted, run the",
+        "acknowledge-qc workflow (Actions tab -> acknowledge-qc -> Run workflow).",
+    ]
     return "\n".join(lines)
 
 
+def acknowledge(issues: pd.DataFrame, path: str = DEFAULT_ACK,
+                categories=None, by: str = "", date: str = "") -> int:
+    """Append current issues to the acknowledged list (dedup by key).
+
+    ``categories`` limits which issue categories are acknowledged (None = all).
+    Existing acknowledgements are preserved. Returns the number newly added.
+    """
+    if os.path.exists(path):
+        existing = pd.read_csv(path, dtype=str).fillna("")
+        for c in ACK_COLUMNS:
+            if c not in existing.columns:
+                existing[c] = ""
+        existing = existing[ACK_COLUMNS]
+    else:
+        existing = pd.DataFrame(columns=ACK_COLUMNS)
+
+    keys = {_key(r["cNPDB ID"], r["category"]) for _, r in existing.iterrows()}
+    rows = []
+    for _, r in issues.iterrows():
+        if categories and r["category"] not in categories:
+            continue
+        k = _key(r["cNPDB ID"], r["category"])
+        if k in keys:
+            continue
+        keys.add(k)
+        rows.append({"cNPDB ID": r["cNPDB ID"], "category": r["category"],
+                     "acknowledged_by": by, "date": date, "reason": "reviewed and accepted"})
+    out = pd.concat([existing, pd.DataFrame(rows, columns=ACK_COLUMNS)], ignore_index=True)
+    out.to_csv(path, index=False)
+    return len(rows)
+
+
+def _today() -> str:
+    from datetime import datetime
+    return datetime.now().strftime("%Y-%m-%d")
+
+
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="QC the DB and emit an email body.")
+    ap = argparse.ArgumentParser(description="QC the DB; alert on new issues or acknowledge.")
     ap.add_argument("--db", default=qc.DEFAULT_DB)
-    ap.add_argument("--out", default=os.path.join(qc.OUTPUTS_DIR, "qc_flagged_issues.csv"))
-    ap.add_argument("--body-out", default=None)
+    ap.add_argument("--out", default=DEFAULT_OUT, help="write the full flagged-issues CSV here")
+    ap.add_argument("--acknowledged", default=DEFAULT_ACK, help="the accepted-issues baseline CSV")
+    ap.add_argument("--body-out", default=None, help="write the email body (new issues) here")
+    ap.add_argument("--acknowledge", action="store_true",
+                    help="record current issues as reviewed/accepted, then exit")
+    ap.add_argument("--categories", default="",
+                    help="comma-separated categories to acknowledge (blank = all currently flagged)")
+    ap.add_argument("--by", default="")
+    ap.add_argument("--date", default=None)
     args = ap.parse_args(argv)
 
     db = qc.load_database(args.db)
     issues = qc.run_all(db)
+
+    if args.acknowledge:
+        cats = [c.strip() for c in args.categories.split(",") if c.strip()] or None
+        added = acknowledge(issues, args.acknowledged, cats,
+                            args.by or "acknowledged via Actions", args.date or _today())
+        print(added)  # number newly acknowledged
+        return added
+
     if args.out:
         issues.to_csv(args.out, index=False)
-    body = build_body(issues, len(db))
+    ack = load_acknowledged(args.acknowledged)
+    new = new_issues(issues, ack)
+    n_suppressed = len(issues) - len(new)
+    body = build_body(new, len(db), n_suppressed)
     if args.body_out:
         with open(args.body_out, "w", encoding="utf-8") as fh:
             fh.write(body)
-    # Stdout is the issue count, for the workflow's send condition.
-    print(len(issues))
-    return len(issues)
+    print(len(new))  # NEW-issue count, for the workflow's send condition
+    return len(new)
 
 
 if __name__ == "__main__":

--- a/notify/HANDOFF.md
+++ b/notify/HANDOFF.md
@@ -13,7 +13,7 @@ plain-English overview for maintainers and the PI.
 | Email | When it sends | What it means |
 |-------|---------------|---------------|
 | **Papers to check** | Monthly (1st, ~08:00 UTC) | A list of new crustacean-neuropeptide papers worth reviewing for new sequences. A paper drops off automatically once its DOI is in the database. |
-| **Database accuracy check** | When the database is pushed | A quality-control summary (wrong masses, missing species, etc.). **Never blocks the update** — the new database goes live regardless; this is a heads-up. |
+| **Database accuracy check** | When the database is pushed | A summary of **new / not-yet-reviewed** QC issues (wrong masses, missing species, etc.). **Never blocks the update** — the new database goes live regardless; this is a heads-up. Reviewed-and-accepted issues can be silenced (see "Clearing QC alerts"). |
 | **Test-failure alert** | Any change to the repo | Sent only if the automated test suite breaks, with a link to the details — so nobody has to watch the Actions tab. |
 
 ## Which database it monitors
@@ -70,10 +70,32 @@ update / repo change for the other two.
 | Workflow file | Purpose | Trigger |
 |---------------|---------|---------|
 | `.github/workflows/lit-mining.yml` | Monthly paper scan + "papers to check" email | schedule (monthly) + manual |
-| `.github/workflows/db-accuracy.yml` | QC on the database + accuracy email | push to `Assets/20260418_cNPDB.*` + manual |
+| `.github/workflows/db-accuracy.yml` | QC on the database + accuracy email (new issues only) | push to `Assets/20260418_cNPDB.*` + manual |
+| `.github/workflows/acknowledge-qc.yml` | Mark reviewed QC issues as accepted so they stop alerting | manual only |
 | `.github/workflows/tests.yml` | Run tests; email on failure | any push / PR + manual |
 | `.github/workflows/curation-refresh.yml` | (pre-existing) regenerate QC/coverage output files | DB or tool change |
 | `.github/actions/notify-email/` | Shared "send an email" step used by all three | — |
+
+## Clearing (acknowledging) QC alerts
+
+The accuracy email only reports issues that are **new or not yet reviewed**. Once
+a human has looked at an issue and decided it's acceptable, you can "acknowledge"
+it so it stops showing up in every future alert:
+
+- **Acknowledged issues** live in `DataCuration/outputs/qc_acknowledged.csv`
+  (matched by cNPDB ID + issue category). It ships with a couple of clearly-marked
+  **example placeholder rows** that clear nothing — replace or ignore them.
+- **To acknowledge** (after review): Actions tab → **acknowledge-qc** → **Run
+  workflow**. Leave the *categories* box blank to accept **all** currently-flagged
+  issues (use carefully), or list specific ones like `missing_OS,missing_DOI` to
+  accept only those. It records them and commits the file; from then on, only
+  genuinely new issues trigger an email.
+- **Nothing is acknowledged automatically** — it's always a deliberate human step.
+
+> Note: the ~250 issues currently in the database (mostly mass discrepancies and
+> missing species) are intentionally **left unacknowledged** so the team keeps
+> seeing them while deciding open questions (e.g. whether the database should
+> report unmodified mass). Acknowledge them only once those decisions are made.
 
 ## What no automatic check can catch
 

--- a/notify/README.md
+++ b/notify/README.md
@@ -59,6 +59,16 @@ to that provider's SMTP credentials. The default is Gmail's server.
 Remove the secrets (or empty `recipients.txt`) and emails stop; the workflows
 keep working. To stop a whole notification, delete or disable its workflow.
 
+## Clearing QC alerts you've reviewed
+
+The database-accuracy email reports only **new / not-yet-reviewed** issues. To
+stop being alerted about issues you've reviewed and accepted, run the
+**acknowledge-qc** workflow (Actions → acknowledge-qc → Run workflow). Leave the
+categories box blank to accept all current issues, or list specific categories
+(e.g. `missing_OS,missing_DOI`). Accepted issues are recorded in
+`DataCuration/outputs/qc_acknowledged.csv` and won't trigger future emails.
+Nothing is acknowledged automatically.
+
 ## What each email can and can't tell you
 
 - The **papers-to-check** list depends on the source **DOI** being recorded when

--- a/tests/test_qc_email.py
+++ b/tests/test_qc_email.py
@@ -1,23 +1,102 @@
 # -*- coding: utf-8 -*-
-"""Tests for the database-accuracy email body builder."""
+"""Tests for the database-accuracy email: baseline filtering + acknowledging."""
 import pandas as pd
 
 from DataCuration import qc_email
 
 
-def test_body_clean_when_no_issues():
-    body = qc_email.build_body(pd.DataFrame(columns=["category", "severity"]), 1516)
-    assert "no flagged issues" in body
+def _issues(*rows):
+    return pd.DataFrame(list(rows), columns=["cNPDB ID", "category", "severity", "detail"])
 
 
-def test_body_summarizes_counts():
-    issues = pd.DataFrame([
-        {"category": "mass_discrepancy", "severity": "high"},
-        {"category": "mass_discrepancy", "severity": "high"},
-        {"category": "missing_OS", "severity": "low"},
-    ])
-    body = qc_email.build_body(issues, 1516)
-    assert "3 flagged QC issue(s)" in body
+# ---------------------------------------------------------------------------
+# Baseline filtering
+# ---------------------------------------------------------------------------
+def test_new_issues_excludes_acknowledged():
+    issues = _issues(
+        {"cNPDB ID": 5, "category": "missing_OS", "severity": "low", "detail": "x"},
+        {"cNPDB ID": 6, "category": "mass_discrepancy", "severity": "high", "detail": "y"},
+    )
+    ack = {("5", "missing_OS")}
+    new = qc_email.new_issues(issues, ack)
+    assert list(new["cNPDB ID"]) == [6]
+
+
+def test_new_issues_empty_acknowledged_returns_all():
+    issues = _issues({"cNPDB ID": 5, "category": "missing_OS", "severity": "low", "detail": "x"})
+    assert len(qc_email.new_issues(issues, set())) == 1
+
+
+def test_acknowledged_match_is_by_id_and_category():
+    # Same ID, different category -> not acknowledged.
+    issues = _issues({"cNPDB ID": 5, "category": "mass_discrepancy", "severity": "high", "detail": "x"})
+    new = qc_email.new_issues(issues, {("5", "missing_OS")})
+    assert len(new) == 1
+
+
+# ---------------------------------------------------------------------------
+# Email body
+# ---------------------------------------------------------------------------
+def test_body_empty_when_no_new_issues():
+    assert qc_email.build_body(_issues(), 1516) == ""
+
+
+def test_body_summarizes_new_and_notes_suppressed():
+    new = _issues(
+        {"cNPDB ID": 1, "category": "mass_discrepancy", "severity": "high", "detail": "a"},
+        {"cNPDB ID": 2, "category": "mass_discrepancy", "severity": "high", "detail": "b"},
+    )
+    body = qc_email.build_body(new, 1516, n_suppressed=3)
+    assert "2 QC issue(s) that are new" in body
     assert "mass_discrepancy: 2" in body
-    assert "high: 2" in body
-    assert "do NOT block" in body
+    assert "3 previously-acknowledged" in body
+    assert "acknowledge-qc" in body
+
+
+def test_body_no_suppressed_note_when_zero():
+    new = _issues({"cNPDB ID": 1, "category": "missing_OS", "severity": "low", "detail": "a"})
+    body = qc_email.build_body(new, 1516, n_suppressed=0)
+    assert "previously-acknowledged" not in body
+
+
+# ---------------------------------------------------------------------------
+# Acknowledging
+# ---------------------------------------------------------------------------
+def test_acknowledge_writes_rows(tmp_path):
+    path = str(tmp_path / "ack.csv")
+    issues = _issues(
+        {"cNPDB ID": 5, "category": "missing_OS", "severity": "low", "detail": "x"},
+        {"cNPDB ID": 6, "category": "missing_DOI", "severity": "low", "detail": "y"},
+    )
+    added = qc_email.acknowledge(issues, path, by="me", date="2026-07-15")
+    assert added == 2
+    assert qc_email.load_acknowledged(path) == {("5", "missing_OS"), ("6", "missing_DOI")}
+
+
+def test_acknowledge_respects_category_filter(tmp_path):
+    path = str(tmp_path / "ack.csv")
+    issues = _issues(
+        {"cNPDB ID": 5, "category": "missing_OS", "severity": "low", "detail": "x"},
+        {"cNPDB ID": 6, "category": "mass_discrepancy", "severity": "high", "detail": "y"},
+    )
+    added = qc_email.acknowledge(issues, path, categories=["missing_OS"])
+    assert added == 1
+    assert qc_email.load_acknowledged(path) == {("5", "missing_OS")}
+
+
+def test_acknowledge_is_idempotent(tmp_path):
+    path = str(tmp_path / "ack.csv")
+    issues = _issues({"cNPDB ID": 5, "category": "missing_OS", "severity": "low", "detail": "x"})
+    assert qc_email.acknowledge(issues, path) == 1
+    assert qc_email.acknowledge(issues, path) == 0  # already there
+    assert len(qc_email.load_acknowledged(path)) == 1
+
+
+def test_seeded_examples_do_not_clear_real_issues(tmp_path):
+    # The shipped placeholder rows use non-existent IDs, so they suppress nothing.
+    seeded = {("9001", "missing_DOI"), ("9002", "missing_OS")}
+    issues = _issues(
+        {"cNPDB ID": 13, "category": "missing_OS", "severity": "low", "detail": "real"},
+        {"cNPDB ID": 121, "category": "missing_DOI", "severity": "low", "detail": "real"},
+    )
+    assert len(qc_email.new_issues(issues, seeded)) == 2


### PR DESCRIPTION
The db-accuracy email now compares QC issues against an acknowledged baseline (DataCuration/outputs/qc_acknowledged.csv) and reports only new / not-yet-reviewed issues, ending re-alerting on known ones. A new acknowledge-qc workflow (Actions -> Run workflow, optional category filter) records reviewed issues as accepted and commits the list; nothing is acknowledged automatically.

The acknowledged file is seeded with clearly-marked placeholder example rows (non-existent IDs) that clear nothing, so the ~250 current issues stay visible for the team's review (incl. the open unmodified-mass question). Docs updated; 10 qc_email tests; full suite 172 passing.